### PR TITLE
ENABLE Jackson to allow Non Numeric Numbers

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,4 +21,8 @@ logging.file=AaaS.log
 spring.servlet.multipart.max-file-size=5GB
 #Total request size for a multipart/form-data cannot exceed 5GB
 spring.servlet.multipart.max-request-size=5GB
+
+# To be able to handle NaN values in datasets
+spring.jackson.parser.ALLOW_NON_NUMERIC_NUMBERS=true
+
   


### PR DESCRIPTION
This enables users of the API to send datasets containing NaN values.
It is the current judgment it is better to be lenient on what to accept
then to force users to conform.